### PR TITLE
feat: add dtekv-upload and dtekv-download tools to navigation

### DIFF
--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -110,9 +110,12 @@ function cpuLoop() {
   requestAnimationFrame(cpuLoop);
 }
 
+export function hardReset() {
+  cpu.set_to_new();
+}
+
 export function loadBinary(binary: Uint8Array) {
   currentLoadedBinary = new Uint8Array(binary);
-  cpu.set_to_new();
   cpu.load(new Uint8Array(binary));
   cpu.reset();
   const loadCallbacks = store.get(cpuLoadCallbacksAtom);
@@ -129,4 +132,12 @@ export function reset() {
 
 export function startCpuLoop() {
   requestAnimationFrame(cpuLoop);
+}
+
+export function loadDataAt(addr: number, data: Uint8Array) {
+  cpu.load_data_at(addr, data);
+}
+
+export function readDataAt(addr: number, length: number): Uint8Array {
+  return cpu.read_data_at(addr, length);
 }

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+/**
+ * A hook that provides a callback called when the user clicks outside the
+ * provided elements.
+ * 
+ * @param elements A list of refs to elements that are concidered "inside".
+ * @param onClickOutside A callback when the user clicks "outside".
+ */
+function useOnClickOutside(
+    elements: React.RefObject<HTMLElement>[],
+    onClickOutside: () => void,
+) {
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        elements.every(
+          (element) => element.current && !element.current.contains(target)
+        )
+      ) {
+        onClickOutside();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [elements, onClickOutside]);
+}
+
+export default useOnClickOutside;

--- a/src/pages/Emulator/views/Nav/Nav.module.css
+++ b/src/pages/Emulator/views/Nav/Nav.module.css
@@ -51,6 +51,57 @@
   background-color: var(--color-background-hover);
 }
 
+.popoutContainer {
+  display: none;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  padding: 12px;
+  position: absolute;
+  flex-direction: column;
+  transform: translateY(100%);
+  bottom: 0px;
+  left: -1px;
+  z-index: 10;
+  width: 300px;
+}
+
+.popoutContainer.active {
+  display: block;
+}
+
+.formInput {
+  font-family: monospace;
+  background-color: var(--color-background-alt);
+  border: 1px solid var(--color-border);
+  color: white;
+  border-radius: 0;
+  outline: 0;
+  padding: 5px 12px;
+  margin: 0px 12px;
+  width: 125px;
+  height: 33px;
+}
+
+.formLabel {
+  display: inline-block;
+  width: 70px;
+}
+
+.uploadInput {
+  margin-top: 10px;
+  margin-left: 13px;
+  width: 180px;
+}
+
+.formButton {
+  background-color: var(--color-background-alt);
+  border: 1px solid var(--color-border);
+  color: white;
+  padding: 5px 12px;
+  margin: 12px 0px;
+  cursor: pointer;
+}
+
 .navButton:hover {
   background-color: var(--color-background-hover);
 }

--- a/src/pages/Emulator/views/Nav/index.tsx
+++ b/src/pages/Emulator/views/Nav/index.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import cx from "../../../../utils/cx";
 
 import styles from "./Nav.module.css";
-import { loadBinary, reset } from "../../../../cpu";
+import {
+  hardReset,
+  loadBinary,
+  loadDataAt,
+  readDataAt,
+  reset,
+} from "../../../../cpu";
 import { GITHUB_URL } from "../../../../consts";
+import useOnClickOutside from "../../../../hooks/useOnClickOutside";
 
 const examples = [
   {
@@ -69,6 +76,7 @@ function Nav() {
           onChange={async (e) => {
             const file = e.currentTarget.files![0];
             const bin = new Uint8Array(await file.arrayBuffer());
+            // hardReset(); // TODO
             loadBinary(bin);
           }}
         />
@@ -77,6 +85,8 @@ function Nav() {
         Reset
       </button>
       <ExampleButton />
+      <DtekvUploadButton />
+      <DtekvDownloadButton />
       <div className={styles.splitter} />
       <a
         className={cx(styles.navButton, styles.right)}
@@ -94,22 +104,9 @@ function ExampleButton() {
   const exampleRef = useRef<HTMLDivElement>(null);
   const exampleButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        exampleRef.current &&
-        exampleButtonRef.current &&
-        !exampleRef.current.contains(event.target as Node) &&
-        !exampleButtonRef.current.contains(event.target as Node)
-      ) {
-        setExampleButtonActive(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [exampleRef]);
+  useOnClickOutside([exampleRef, exampleButtonRef], () =>
+    setExampleButtonActive(false)
+  );
 
   return (
     <div className={styles.wrapper}>
@@ -132,6 +129,7 @@ function ExampleButton() {
               key={id}
               onClick={async () => {
                 setExampleButtonActive(false);
+                hardReset();
                 loadBinary(await bin);
               }}
             >
@@ -142,6 +140,222 @@ function ExampleButton() {
       </div>
     </div>
   );
+}
+
+function parseAddress(str: string): number | null {
+  const addr = str.startsWith("0x")
+    ? parseInt(str.substring(2), 16)
+    : parseInt(str);
+  if (isNaN(addr) || addr < 0) {
+    return null;
+  }
+  return addr;
+}
+
+function showError(ref: React.RefObject<HTMLInputElement>, error: string) {
+  ref.current?.setCustomValidity(error);
+  ref.current?.reportValidity();
+}
+
+function DtekvUploadButton() {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const addressRef = useRef<HTMLInputElement>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [active, setActive] = useState(false);
+  const [address, setAddress] = useState("0x00000000");
+
+  useOnClickOutside([contentRef, buttonRef], () => setActive(false));
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        ref={buttonRef}
+        onClick={() => {
+          setActive(!active);
+        }}
+        className={styles.navButton}
+      >
+        dtekv-upload
+      </button>
+      <div
+        ref={contentRef}
+        className={cx(styles.popoutContainer, active && styles.active)}
+      >
+        <div>
+          <label htmlFor="dtekv-upload-addr" className={styles.formLabel}>
+            Address
+          </label>
+          <input
+            ref={addressRef}
+            id="dtekv-upload-addr"
+            className={styles.formInput}
+            value={address}
+            onInput={(e) => setAddress((e.target as HTMLInputElement).value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="dtekv-upload-file" className={styles.formLabel}>
+            Content
+          </label>
+          <input
+            ref={fileInput}
+            id="dtekv-upload-file"
+            type="file"
+            className={styles.uploadInput}
+            required
+          />
+        </div>
+        <div>
+          <button
+            className={styles.formButton}
+            onClick={async () => {
+              const addr = parseAddress(address);
+              if (addr === null) {
+                showError(addressRef, "Please provide an address.");
+                return;
+              }
+              const file = fileInput.current?.files?.[0];
+              if (!file) {
+                showError(fileInput, "Please select a file to upload.");
+                return;
+              }
+
+              setActive(false);
+              const data = new Uint8Array(await file.arrayBuffer());
+              loadDataAt(addr, data);
+            }}
+          >
+            Upload
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DtekvDownloadButton() {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const fileNameInput = useRef<HTMLInputElement>(null);
+  const addressInput = useRef<HTMLInputElement>(null);
+  const lengthInput = useRef<HTMLInputElement>(null);
+  const [active, setActive] = useState(false);
+  const [fileName, setFileName] = useState("data.bin");
+  const [address, setAddress] = useState("0x00000000");
+  const [length, setLength] = useState(1024);
+
+  useOnClickOutside([contentRef, buttonRef], () => setActive(false));
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        ref={buttonRef}
+        onClick={() => {
+          setActive(!active);
+        }}
+        className={styles.navButton}
+      >
+        dtekv-download
+      </button>
+      <div
+        ref={contentRef}
+        className={cx(styles.popoutContainer, active && styles.active)}
+      >
+        <div>
+          <label htmlFor="dtekv-download-filename" className={styles.formLabel}>
+            Filename
+          </label>
+          <input
+            ref={fileNameInput}
+            id="dtekv-download-filename"
+            className={styles.formInput}
+            value={fileName}
+            onInput={(e) => setFileName((e.target as HTMLInputElement).value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="dtekv-download-addr" className={styles.formLabel}>
+            Address
+          </label>
+          <input
+            ref={addressInput}
+            id="dtekv-download-addr"
+            className={styles.formInput}
+            value={address}
+            onInput={(e) => setAddress((e.target as HTMLInputElement).value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="dtekv-download-length" className={styles.formLabel}>
+            Length
+          </label>
+          <input
+            ref={lengthInput}
+            id="dtekv-download-length"
+            className={styles.formInput}
+            type="number"
+            min={0}
+            required
+            value={length || ""}
+            onInput={(e) =>
+              setLength(parseInt((e.target as HTMLInputElement).value))
+            }
+          />
+        </div>
+        <div>
+          <button
+            className={styles.formButton}
+            onClick={async () => {
+              const addr = parseAddress(address);
+              if (!fileName) {
+                showError(fileNameInput, "Please provide a file name.");
+                return;
+              }
+              if (addr === null) {
+                showError(addressInput, "Please provide an address.");
+                return;
+              }
+              if (isNaN(length) || length <= 0) {
+                showError(
+                  lengthInput,
+                  "Please provide an amount of bytes to download."
+                );
+                return;
+              }
+
+              setActive(false);
+              let data: Uint8Array;
+              try {
+                data = readDataAt(addr, length);
+              } catch (e) {
+                alert(e);
+                return;
+              }
+              const blob = new Blob([data]);
+              downloadBlob(blob, fileName);
+            }}
+          >
+            Download
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  URL.revokeObjectURL(url);
 }
 
 export default Nav;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -170,4 +170,20 @@ impl Cpu {
         }
         self.internal_cpu.bus.clock();
     }
+
+    pub fn load_data_at(&mut self, addr: u32, data: Vec<u8>) {
+        self.sdram.borrow_mut().load_data_at(addr, data);
+    }
+
+    pub fn read_data_at(&self, addr: u32, length: usize) -> Result<Vec<u8>, JsError> {
+        let mut buf: Vec<u8> = Vec::with_capacity(length);
+        let sdram = self.sdram.borrow();
+        for i in 0..length {
+            let byte = sdram
+                .load_byte(addr + i as u32)
+                .map_err(|_| JsError::new("Out of range."))?;
+            buf.push(byte);
+        }
+        Ok(buf)
+    }
 }


### PR DESCRIPTION
Awesome emulator btw!

This PR adds buttons to be able to upload and download data to/from memory. It's useful for projects like ours that require uploading certain files/data to the board before running the binary.